### PR TITLE
[add] #40 Formで得たデータをreduxで管理できるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "firebase": "^8.0.0",
+    "nanoid": "^3.1.16",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/src/components/pages/Form.jsx
+++ b/src/components/pages/Form.jsx
@@ -5,6 +5,9 @@ import TextField from '@material-ui/core/TextField';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import { useForm } from 'react-hook-form';
+import { useDispatch,useSelector } from "react-redux"
+import SLICE from "../../reducks/list/formSlice"
+import { nanoid } from "nanoid"
 
 const use_style = makeStyles((theme) => ({
   paper: {
@@ -26,9 +29,14 @@ const use_style = makeStyles((theme) => ({
 }));
 
 export default function Form() {
+  const formdata = useSelector(state => state.form)
+  console.log(formdata)
+  const dispacth = useDispatch()
   const classes = use_style();
   const { register, errors, handleSubmit } = useForm();
-  const submit = (data) => console.log(data)
+  const submit = (data) => {
+    dispacth (SLICE.actions.setForm({text:data.detail,title:data.title,url:data.url,id:nanoid()}))
+  }
   return (
     <Container component="main" maxWidth="xs">
       <CssBaseline />

--- a/src/reducks/list/formSlice.jsx
+++ b/src/reducks/list/formSlice.jsx
@@ -1,0 +1,15 @@
+import { createSlice } from "@reduxjs/toolkit"
+
+const SLICE = createSlice({
+  name: "form",
+  initialState:[],
+  reducers: {
+    setForm: (state,action) => action.payload,
+    clearForm: (state, action) => state.filter(el => el.id !== action.payload),
+  },
+  extraReducers: {
+    
+  }
+});
+
+export default SLICE;

--- a/src/reducks/list/listSlice.jsx
+++ b/src/reducks/list/listSlice.jsx
@@ -6,6 +6,9 @@ const slice = createSlice({
   reducers: {
     addList: (state, action) => [...state, action.payload],
     deleteList: (state, action) => state.filter(el => el.id !== action.payload),
+  },
+  extraReducers: {
+    
   }
 });
 

--- a/src/reducks/store.jsx
+++ b/src/reducks/store.jsx
@@ -1,8 +1,8 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
-import slice from "./list/listSlice";
+import SLICE from "./list/formSlice"
 
 const Reducer = combineReducers({
-  list: slice.reducer,
+  form: SLICE.reducer,
 });
 
 const store = configureStore({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7655,6 +7655,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^3.1.16:
+  version "3.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
+  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
## Issue

Closes #40 

## 今回の PR で行ったこと

- formで得たデータをreduxで管理できるようにする

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- formに文字を入れてADDをクリックしてconsoleに表示されているか確認した。
表示された。

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

- formに影響が及ぶようになった。

## 実装するにあたって参考にした URL

- https://www.hypertextcandy.com/learn-react-redux-with-hooks-and-redux-starter-kit
## 確認して欲しいこと

- consoleにformのデータが上手く表示されているか

## 懸念点

- なし
