### PR TITLE
[add] #72リストのルーティングの実装とreduxからタイトルを取ってくる

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[1125/173646.759:ERROR:directory_reader_win.cc(43)] FindFirstFile: 指定されたパスが見つかりません。 (0x3)

--- a/src/App.js
+++ b/src/App.js
@@ -48,7 +48,7 @@ function App() {
               component={List}
             />
             <Route
-              exact path="/detail"
+              exact path="/detail/:id"
               component={Detail}
             />
           </Switch>

--- a/src/components/pages/List.jsx
+++ b/src/components/pages/List.jsx
@@ -1,10 +1,12 @@
-import React,{useState} from 'react';
+import React, { useState } from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
-import Listitem from "../templates/Listitem";
-import {useSelector} from "react-redux"
-import Pagenation from "@material-ui/lab/Pagination"
+import Listitem from '../templates/Listitem';
+import { useSelector } from 'react-redux';
+import Pagenation from '@material-ui/lab/Pagination';
+import { useEffect } from 'react';
+import firebase from '../../firebase/firebase';
 
 const use_style = makeStyles((theme) => ({
   paper: {
@@ -15,39 +17,56 @@ const use_style = makeStyles((theme) => ({
   form: {
     width: '100%', // Fix IE 11 issue.
     marginTop: theme.spacing(1),
-  }
+  },
 }));
 
 export default function List() {
-  const [pagenumber,set_pagenumber]=useState(0)
-  const RED = '#99cccc'
-  const BLUE = '#008080'
-  const MAX=9
+  const [pagenumber, set_pagenumber] = useState(0);
+  const RED = '#99cccc';
+  const BLUE = '#008080';
+  const MAX = 9;
   const classes = use_style();
-  const list = useSelector(state => state.lists)
+  const [idurl, setIdUrl] = useState([]);
+  const list = useSelector((state) => state.lists);
   const sliceByNumber = (array, number) => {
-    const length = Math.ceil(array.length / number)
-    return new Array(length).fill().map((_, i) =>
-      array.slice(i * number, (i + 1) * number)
-    )
-  }
-  const tenList=sliceByNumber(list, MAX)
-  const listcount=Math.ceil(list.length/10)
-  console.log(listcount)
-  const pageChange=(e,value)=>{
-    set_pagenumber(value-1)
-  }
+    const length = Math.ceil(array.length / number);
+    return new Array(length)
+      .fill()
+      .map((_, i) => array.slice(i * number, (i + 1) * number));
+  };
+  const tenList = sliceByNumber(list, MAX);
+  const listcount = Math.ceil(list.length / 10);
+  // console.log(listcount)
+  const pageChange = (e, value) => {
+    set_pagenumber(value - 1);
+  };
+
+  useEffect(() => {
+    firebase
+      .firestore()
+      .collection('/messages')
+      .onSnapshot((snapshot) => {
+        const docid = snapshot.docs.map((doc) => {
+          return doc.id;
+        });
+        setIdUrl(docid);
+      });
+  }, []);
+
   return (
     <Container component="main" maxWidth="xs">
       <CssBaseline />
       <div className={classes.paper}>
         <div className={classes.form}>
-          {tenList[pagenumber]?.map((listitem, index) => ((index % 2) !== 0 ?
-            <Listitem color={RED} listitem={listitem} key={listitem.title} /> :
-            <Listitem color={BLUE} listitem={listitem} key={listitem.title} />
-          ))}
+          {idurl.map((docid, index) =>
+            index % 2 !== 0 ? (
+              <Listitem color={RED} docid={docid} key={docid} />
+            ) : (
+              <Listitem color={BLUE} docid={docid} key={docid} />
+            )
+          )}
         </div>
-        <Pagenation count={listcount} onChange={pageChange} color="primary"/>
+        <Pagenation count={listcount} onChange={pageChange} color="primary" />
       </div>
     </Container>
   );

--- a/src/components/templates/Listitem.jsx
+++ b/src/components/templates/Listitem.jsx
@@ -1,27 +1,41 @@
 import React from 'react';
 import Rating from '@material-ui/lab/Rating';
-import { makeStyles } from "@material-ui/core/styles"
+import { Link } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import { useSelector } from 'react-redux';
 
-const Listitem = ({listitem,color}) => {
-  
+const Listitem = ({ color, docid }) => {
+  const listitems = useSelector((state) => state.lists);
+  // console.log(listitems)
+  const listitem = listitems.find((e) => e.documentID === docid);
+  console.log(listitem);
   const use_style = makeStyles({
-    container:{
-      fontSize: "16px",
+    container: {
+      fontSize: '16px',
       backgroundColor: color,
-      display: "flex",
-      justifyContent: "space-around",
-      alignItems: "center"
-    }})
+      display: 'flex',
+      justifyContent: 'space-around',
+      alignItems: 'center',
+    },
+    title: {
+      textDecoration: 'none',
+      color: 'black'
+    }
+  });
 
-  const classes = use_style()
+  const classes = use_style();
 
   return (
     <div className={classes.container}>
       <h4>title</h4>
-      <p>{listitem.title}</p>
-      <div><Rating readOnly /></div>
+      <Link className={classes.title} to={`/detail/${docid}`}>
+        {listitem?.title}
+      </Link>
+      <div>
+        <Rating readOnly />
+      </div>
     </div>
-  )
-}
+  );
+};
 
-export default Listitem
+export default Listitem;


### PR DESCRIPTION
## Issue

Closes #72 

## 今回の PR で行ったこと

### リストから、idを取ってきて、urlに乗せて、ルーティングできるようにした。また、タイトルをreduxからとってきて、list画面に表示した。

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

### タイトルの表示を確認した。

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

### リストのタイトルを押すと、ルーティングできるようになった

## 実装するにあたって参考にした URL

### https://www.youtube.com/playlist?list=PLX8Rsrpnn3IWavNOj3n4Vypzwb3q1RXhr

## 確認して欲しいこと。

### 正しく動くかどうか

## 懸念点

### 特になし。
